### PR TITLE
Invoke gdb through libtool `--mode=execute`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ test: test-bin
 
 .PHONY: gdb
 gdb: test-bin
-	gdb -x .gdb $(TEXE)
+	$(LIBTOOL) --mode=execute gdb -x .gdb $(TEXE)
 
 .PHONY: coverage
 coverage: tools $(COVOUT)


### PR DESCRIPTION
Now that `-rpath` is passed to libtool, gdb can't be invoked directly on the
test program because it is a wrapper script.