### PR TITLE
Add "exiting" flag to parser struct

### DIFF
--- a/src/object.h
+++ b/src/object.h
@@ -40,6 +40,7 @@ typedef struct mpack_node_s {
     mpack_data_t data;              \
     mpack_uint32_t size, capacity;  \
     int status;                     \
+    int exiting;                    \
     mpack_tokbuf_t tokbuf;          \
     mpack_node_t items[c + 1];      \
   }


### PR DESCRIPTION
This flag is used to normalize how leaf `mpack_node_t` instances are treated by
the `mpack_unparse_tok` function. With this change, `mpack_unparse_tok` will
return after `enter_cb` is invoked(previously this only happened on non-leaf
nodes).

This was done mainly to give `mpack_unparse` a chance to invoke `mpack_write`
before `exit_cb` is invoked on leaf nodes, which is necessary in cases where the
user's `exit_cb` frees some buffer read by `mpack_write`.