### PR TITLE
[lua] Fix build errors for lua 5.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,16 +37,38 @@ matrix:
     - os: osx
       env: CONFIG=release
       compiler: gcc
+    # lua binding builds(TODO: this is starting to get messy, lua binding should
+    # probably be moved into its own repository)
     - os: linux
       compiler: gcc
-      env: CONFIG=lua-binding  # set for the description in travis UI
+      env: CONFIG=lua-5.1-binding  # set for the description in travis UI
       addons:
         apt:
           packages:
             - valgrind
       script:
         - make config=amalgamation
-        - if ! make -C binding/lua valgrind; then cat binding/lua/valgrind.log; exit 1; fi
+        - if ! make MPACK_LUA_VERSION=5.1.5 -C binding/lua ci-test; then cat binding/lua/valgrind.log; exit 1; fi
+    - os: linux
+      compiler: gcc
+      env: CONFIG=lua-5.2-binding  # set for the description in travis UI
+      addons:
+        apt:
+          packages:
+            - valgrind
+      script:
+        - make config=amalgamation
+        - if ! make MPACK_LUA_VERSION=5.2.4 -C binding/lua ci-test; then cat binding/lua/valgrind.log; exit 1; fi
+    - os: linux
+      compiler: gcc
+      env: CONFIG=lua-5.3-binding  # set for the description in travis UI
+      addons:
+        apt:
+          packages:
+            - valgrind
+      script:
+        - make config=amalgamation
+        - if ! make MPACK_LUA_VERSION=5.3.3 -C binding/lua ci-test; then cat binding/lua/valgrind.log; exit 1; fi
 
 script:
   make config=${CONFIG} test
@@ -55,6 +77,8 @@ cache:
   directories:
     - .deps/usr
     - binding/lua/.deps/5.1.5/usr
+    - binding/lua/.deps/5.2.4/usr
+    - binding/lua/.deps/5.3.3/usr
 
 after_failure:
   cat asan.* ubsan.* msan.* || true

--- a/binding/lua/lmpack.c
+++ b/binding/lua/lmpack.c
@@ -30,6 +30,11 @@
 #define NIL_NAME "mpack.Nil"
 
 #if LUA_VERSION_NUM > 501
+/* 
+ * TODO(tarruda): When targeting lua 5.3 and being compiled with `long long`
+ * support(not -ansi), we should make use of lua 64 bit integers for
+ * representing msgpack integers, since `double` can't represent the full range.
+ */
 typedef luaL_Reg luaL_reg;
 #define luaL_register(L, name, lreg) (luaL_setfuncs((L), (lreg), 0))
 #define lua_objlen(L, idx) (lua_rawlen(L, (idx)))


### PR DESCRIPTION
- Prefix Makefile version variables with `MPACK_`. It seems like some
  `LUA_VERSION` variables were leaking into build system of lua/luarocks,
  affecting the resulting directory structure and causing build failures.
- Handle lua 5.3 `long long` check by passing `-DLUA_C89_NUMBERS` to the
  compiler(TODO: should eventually support lua 5.3 64 bit integers)
- Add builds for lua 5.2 and 5.3