### PR TITLE
Fix some travis builds

### DIFF
--- a/.config/armeb.mk
+++ b/.config/armeb.mk
@@ -1,12 +1,14 @@
 unexport CC
-LINARO_URL := https://releases.linaro.org/15.06/components/toolchain/binaries/4.8/armeb-linux-gnueabihf/gcc-linaro-4.8-2015.06-x86_64_armeb-linux-gnueabihf.tar.xz
+LINARO_V := 6.2.1-2016.11
+LINARO_V_NOPATCH := 6.2-2016.11
+LINARO_URL := https://releases.linaro.org/components/toolchain/binaries/$(LINARO_V_NOPATCH)/armeb-linux-gnueabihf/gcc-linaro-$(LINARO_V)-x86_64_armeb-linux-gnueabihf.tar.xz
 QEMU_URL   := https://github.com/qemu/qemu/archive/stable-2.4.tar.gz
 DEPS       := $(shell pwd)/.deps
 DPREFIX    := $(DEPS)/usr
 RUNNER     := $(DPREFIX)/bin/qemu-armeb
 TPREFIX    := $(DPREFIX)/bin/armeb-linux-gnueabihf-
-COMPILER   := $(TPREFIX)gcc
-CC         := $(COMPILER)
+C_COMPILER := $(TPREFIX)gcc
+CC         := $(C_COMPILER)
 AR         := $(TPREFIX)ar
 RANLIB     := $(TPREFIX)ranlib
 LINK       := $(CC)
@@ -25,7 +27,8 @@ $(RUNNER):
 		make install
 	@rm -rf $(DEPS)/src
 
-$(COMPILER):
+$(C_COMPILER):
 	mkdir -p $(DPREFIX)
 	@echo installing linaro toolchain...
+	@echo fetch $(LINARO_URL)
 	@$(FETCH) $(LINARO_URL) | tar xJf - --strip-components=1 -C $(DPREFIX)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: c
-compiler: clang
+compiler: clang-3.8
 
 env:
   global:
@@ -13,6 +13,14 @@ env:
     - CONFIG=release CFLAGS=-Werror
     - CONFIG=amalgamation CFLAGS=-Werror
     - CONFIG=release ANSI=1 CFLAGS=-Werror
+
+addons:
+  apt:
+    packages:
+      - clang-3.8
+    sources:
+      - llvm-toolchain-precise-3.8
+      - ubuntu-toolchain-r-test
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,16 +45,38 @@ matrix:
     - os: osx
       env: CONFIG=release
       compiler: gcc
+    # lua binding builds(TODO: this is starting to get messy, lua binding should
+    # probably be moved into its own repository)
     - os: linux
       compiler: gcc
-      env: CONFIG=lua-binding  # set for the description in travis UI
+      env: CONFIG=lua-5.1-binding  # set for the description in travis UI
       addons:
         apt:
           packages:
             - valgrind
       script:
         - make config=amalgamation
-        - if ! make -C binding/lua valgrind; then cat binding/lua/valgrind.log; exit 1; fi
+        - if ! make MPACK_LUA_VERSION=5.1.5 -C binding/lua ci-test; then cat binding/lua/valgrind.log; exit 1; fi
+    - os: linux
+      compiler: gcc
+      env: CONFIG=lua-5.2-binding  # set for the description in travis UI
+      addons:
+        apt:
+          packages:
+            - valgrind
+      script:
+        - make config=amalgamation
+        - if ! make MPACK_LUA_VERSION=5.2.4 -C binding/lua ci-test; then cat binding/lua/valgrind.log; exit 1; fi
+    - os: linux
+      compiler: gcc
+      env: CONFIG=lua-5.3-binding  # set for the description in travis UI
+      addons:
+        apt:
+          packages:
+            - valgrind
+      script:
+        - make config=amalgamation
+        - if ! make MPACK_LUA_VERSION=5.3.3 -C binding/lua ci-test; then cat binding/lua/valgrind.log; exit 1; fi
 
 script:
   make config=${CONFIG} test
@@ -63,6 +85,8 @@ cache:
   directories:
     - .deps/usr
     - binding/lua/.deps/5.1.5/usr
+    - binding/lua/.deps/5.2.4/usr
+    - binding/lua/.deps/5.3.3/usr
 
 after_failure:
   cat asan.* ubsan.* msan.* || true

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ifneq "$(strip $(findstring clang,$(CC)))" ""
   # When CC is set to clang-${VERSION}, it is very likely that other llvm
   # tools are installed with the same version suffix, so use it for
   # llvm-symbolizer
-  SYMBOLIZER ?= $(shell which $(subst clang,llvm-symbolizer,$(CC)))
+  SYMBOLIZER ?= $(shell realpath $$(which $(subst clang,llvm-symbolizer,$(CC))))
 endif
 
 SYMBOLIZER ?= /usr/bin/llvm-symbolizer
@@ -73,7 +73,7 @@ all: lib-bin test-bin
 include .config/$(config).mk
 
 .PHONY: tools
-tools: $(COMPILER) $(RUNNER)
+tools: $(C_COMPILER) $(RUNNER)
 
 .PHONY: amalgamation
 amalgamation: $(AMALG)

--- a/binding/lua/lmpack.c
+++ b/binding/lua/lmpack.c
@@ -30,6 +30,11 @@
 #define NIL_NAME "mpack.Nil"
 
 #if LUA_VERSION_NUM > 501
+/* 
+ * TODO(tarruda): When targeting lua 5.3 and being compiled with `long long`
+ * support(not -ansi), we should make use of lua 64 bit integers for
+ * representing msgpack integers, since `double` can't represent the full range.
+ */
 typedef luaL_Reg luaL_reg;
 #define luaL_register(L, name, lreg) (luaL_setfuncs((L), (lreg), 0))
 #define lua_objlen(L, idx) (lua_rawlen(L, (idx)))


### PR DESCRIPTION
- Prefix Makefile version variables with `MPACK_`. It seems like some
      `LUA_VERSION` variables were leaking into build system of lua/luarocks,
      affecting the resulting directory structure and causing build failures.
- Handle lua 5.3 `long long` check by passing `-DLUA_C89_NUMBERS` to the
      compiler(TODO: should eventually support lua 5.3 64 bit integers)
- Add builds for lua 5.2 and 5.3
- Run the leak_check.lua script
- Update linaro toolchain URL for the armeb build
- Upgrade clang to 3.8 for the msan build
