### PR TITLE
Allow parse/unparse callbacks to stop execution.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
       env:
         - CONFIG=armeb CFLAGS='-DNDEBUG -g --coverage -Werror' LDFLAGS=--coverage
       before_install:
-        - pip install --user cpp-coveralls
+        - pip install --user cpp-coveralls 'requests[security]'
       after_success:
         - coveralls -b . --gcov $(pwd)/.deps/usr/bin/armeb-linux-gnueabihf-gcov --gcov-options '\-lp'
     - os: osx

--- a/src/object.h
+++ b/src/object.h
@@ -10,7 +10,14 @@
 
 #define MPACK_PARENT_NODE(n) (((n) - 1)->pos == (size_t)-1 ? NULL : (n) - 1)
 
+#define MPACK_THROW(parser)           \
+  do {                                \
+    parser->status = MPACK_EXCEPTION; \
+    return;                           \
+  } while (0)
+
 enum {
+  MPACK_EXCEPTION = -1,
   MPACK_NOMEM = MPACK_ERROR + 1
 };
 
@@ -29,7 +36,7 @@ typedef struct mpack_node_s {
   size_t pos;
   /* flag to determine if the key was visited when traversing a map */
   int key_visited;
-  /* allow 2 instances mpack_data_t per node. the rationale is that when
+  /* allow 2 instances mpack_data_t per node. the reason is that when
    * serializing, the user may need to keep track of traversal state besides the
    * parent node reference */
   mpack_data_t data[2];


### PR DESCRIPTION
This is useful to throw exceptions from language bindings.